### PR TITLE
remove dependent destroy statements

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,6 @@
 class Assignment < ApplicationRecord
   validates_presence_of :user
   validates_presence_of :customer
-  belongs_to :customer, dependent: :destroy
-  belongs_to :user, dependent: :destroy
+  belongs_to :customer
+  belongs_to :user
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,6 +6,6 @@ class Service < ApplicationRecord
     validates :phone_number, numericality: { only_integer: true }
     validates :phone_number, length: { is: 10}
     has_one_attached :picture
-    has_many :orders
-    has_many :customers, through: :orders    
+    has_many :orders, dependent: :delete_all
+    has_many :customers, through: :orders
 end


### PR DESCRIPTION
The assignment dependent destroy statements did not belong there, and were causing the deletion of users and customers when an assignment was deleted.  Also added a dependent delete for services to delete orders if the corresponding service is deleted.