### PR TITLE
change the development active storage to the local instead of amazon

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,8 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  #config.active_storage.service = :local
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
+  #config.active_storage.service = :amazon
   
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
@jrmcgarvey John Do u mind to chek this PR.  This is just a small change: develop active storage to the local instead of amazon.