### PR TITLE
Rspec v2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,34 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale }
   end
 
+  def admin?
+    if current_user.nil?
+      return false
+    end
+    if current_user.role.nil?
+      return false
+    end
+    current_user.role.include?("administrator")
+  end
+
+  def intern?
+    if current_user.nil?
+      return false
+    end
+    if current_user.role.nil?
+      return false
+    end
+    current_user.role.include?("intern")
+  end
+
+  def volunteer?
+    if current_user.nil?
+      return false
+    end
+    if current_user.role.nil?
+      return false
+    end
+    current_user.role.include?("volunteer")
+  end
 end
-
-
-  # def set_locale
-  #   I18n.locale = params[:locale] if params[:locale].present?
-  # end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -67,7 +67,7 @@ class AssignmentsController < ApplicationController
     if !@customer.nil?
       redirect_to @customer
     else
-      redirect_to customer_path
+      redirect_to customers_path
     end
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,7 @@
 class CategoriesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
   include ApplicationHelper
+  
   before_action :authenticate_user!
   before_action :set_category, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,9 @@
 class OrdersController < ApplicationController
+  include ApplicationHelper
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
   before_action :set_order, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
+  before_action :is_user_authorized_order?
 
   # GET /orders
   # GET /orders.json
@@ -75,5 +77,35 @@ class OrdersController < ApplicationController
       else
         redirect_to customers_path
       end
+    end
+
+    def admin?
+      if current_user.nil?
+        return false
+      end
+      if current_user.role.nil?
+        return false
+      end
+      current_user.role.include?("administrator")
+    end
+
+    def intern?
+      if current_user.nil?
+        return false
+      end
+      if current_user.role.nil?
+        return false
+      end
+      current_user.role.include?("intern")
+    end
+
+    def volunteer?
+      if current_user.nil?
+        return false
+      end
+      if current_user.role.nil?
+        return false
+      end
+      current_user.role.include?("volunteer")
     end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,13 +1,20 @@
+require 'application_controller.rb'
+
 class OrdersController < ApplicationController
+  # include ApplicationController
   include ApplicationHelper
+
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
   before_action :set_order, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
-  before_action :is_user_authorized_order?
+  before_action :is_user_authorized_order, except: [:show]
 
   # GET /orders
   # GET /orders.json
   def show
+
+    # logic to see if a user is an adm || intern then can see all 
+    # volunteer - only show for assigned customers
   end
 
   def new
@@ -77,35 +84,5 @@ class OrdersController < ApplicationController
       else
         redirect_to customers_path
       end
-    end
-
-    def admin?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("administrator")
-    end
-
-    def intern?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("intern")
-    end
-
-    def volunteer?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("volunteer")
     end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,5 +1,8 @@
+require 'application_controller.rb'
+
 class ServicesController < ApplicationController
   include ApplicationHelper
+
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
   before_action :authenticate_user!, except: [:show, :index]
   before_action :is_user_authorized?, except: [:show, :index]
@@ -96,25 +99,5 @@ class ServicesController < ApplicationController
       Rails.logger.debug("We had a not found exception.")
       flash.alert = e.to_s
       redirect_to services_path
-    end
-
-    def admin?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("administrator")
-    end
-
-    def intern?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("intern")
     end
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,6 +1,10 @@
+require 'application_controller.rb'
+
 class VideosController < InheritedResources::Base
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
   include ApplicationHelper
+
+
   #layout 'video_layout'
   before_action :authenticate_user!, except: [:show, :index]
   before_action :is_user_authorized?, except: [:show, :index]
@@ -104,25 +108,5 @@ class VideosController < InheritedResources::Base
       Rails.logger.debug("We had a not found exception.")
       flash.alert = e.to_s
       redirect_to videos_path
-    end
-
-    def admin?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("administrator")
-    end
-
-    def intern?
-      if current_user.nil?
-        return false
-      end
-      if current_user.role.nil?
-        return false
-      end
-      current_user.role.include?("intern")
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,23 @@
 module ApplicationHelper
 
-    def is_user_authorized?
-        if intern? || admin?
-          return 
-        else
-          flash[:error] = "You are not authorize for this operation."
-          redirect_to services_path
-        end
+  def is_user_authorized?
+      if intern? || admin?
+        return 
+      else
+        flash[:error] = "You are not authorize for this operation."
+        redirect_to services_path
+      end
+  end
+
+  def is_user_authorized_order?
+    if intern? || admin?
+      return 
+    elsif volunteer?
+      @customers = current_user.customers
+    else
+      flash[:error] = "You are not authorize for this operation."
+      redirect_to new_user_session_path
     end
+  end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,19 +4,17 @@ module ApplicationHelper
       if intern? || admin?
         return 
       else
-        flash[:error] = "You are not authorize for this operation."
+        flash[:error] = "You are not authorized for this operation."
         redirect_to services_path
       end
   end
 
-  def is_user_authorized_order?
+  def is_user_authorized_order
     if intern? || admin?
-      return 
-    elsif volunteer?
-      @customers = current_user.customers
+      return
     else
-      flash[:error] = "You are not authorize for this operation."
-      redirect_to new_user_session_path
+      flash[:error] = "You are not authorized for this operation."
+      redirect_to home_index_path
     end
   end
 

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -1,3 +1,5 @@
+require 'faker'
+
 FactoryBot.define do
   factory :assignment do
     association :customer

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,3 +1,5 @@
+require 'faker'
+
 FactoryBot.define do
   factory :order do
     # product_name { "MyString" }

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -1,34 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe "Assignments", type: :request do
-
-  # describe "get assignments_index_path" do
-  #   it "renders the index view" do
-  #     customer = FactoryBot.create(:customer)
-  #     assignments = FactoryBot.create_list(:assignment, 10)
-  #     user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
-  #     sign_in user
-  #     get customer_assignments_path(customer_id: customer.id)
-  #     expect(response.status).to render_template(:index)
-  #   end
-  # end
-
-  describe "get assignment_path" do
-    it "doesn't renders the :show template if not logged in" do
+  describe "get show_assignment_path" do
+    it "doesn't render the :show template if a user is not logged in" do
       assignment = FactoryBot.create(:assignment)
       get assignment_path(id: assignment.id)
       expect(response).to redirect_to(new_user_session_path)
     end
-    it "renders the :show template" do
+    it "renders the :show template for an administrator role" do
       assignment = FactoryBot.create(:assignment)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get assignment_path(id: assignment.id)
       expect(response).to render_template(:show)
     end
-    it "renders the :show template - redirects to the index path if the assignment id is invalid" do
+    it "renders the :show template for a volunteer" do
       assignment = FactoryBot.create(:assignment)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "volunteer")
+      sign_in user
+      get assignment_path(id: assignment.id)
+      expect(response).to render_template(:show)
+    end
+    it "redirects to the customer index path if the assignment id is invalid" do
+      assignment = FactoryBot.create(:assignment)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get assignment_path(id: 5000)
       expect(response).to redirect_to customers_path
@@ -36,7 +34,7 @@ RSpec.describe "Assignments", type: :request do
   end
 
   describe "get new_customer_assignment_path" do
-    it "renders the :new template" do
+    it "renders the :new template for an administrator role" do
       customer = FactoryBot.create(:customer)
       assignment = FactoryBot.create(:assignment)
       user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
@@ -46,31 +44,34 @@ RSpec.describe "Assignments", type: :request do
         params: {assignment: {status: "new"}}
       expect(response).to render_template(:new)
     end
-  end
-
-  describe "get new_customer_assignment_path" do
-    it "renders the :new template - redirects to the index path if the the user role is invalid" do
+    it "redirects to the new_user_session_path if a user is not logged in" do
       customer = FactoryBot.create(:customer)
       assignment = FactoryBot.create(:assignment)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "stranger")
-      sign_in user
-      get new_customer_assignment_path(customer_id: customer.id, assignment_id: assignment.id)
-      # expect(response.status).to eq(404)
-      expect(response).to redirect_to home_index_path
+      get new_customer_assignment_path(customer_id: customer.id, 
+        assignment_id: assignment.id)
+      expect(response).to redirect_to new_user_session_path
     end
   end
 
   describe "get edit_assignment_path" do
-    it "renders the :edit template" do
+    it "renders the :edit template for an administrator role" do
       assignment = FactoryBot.create(:assignment)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get edit_assignment_path(id: assignment.id)
+      expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
-    it "renders the :edit template - redirects to the index path if the assignment id is invalid" do
+    it "redirects to the new_user_session_path if a user is not logged in" do
       assignment = FactoryBot.create(:assignment)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      get edit_assignment_path(id: assignment.id)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+    it "redirects to the index path if the assignment id is invalid" do
+      assignment = FactoryBot.create(:assignment)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get assignment_path(id: 5000)
       expect(response).to redirect_to customers_path
@@ -79,7 +80,8 @@ RSpec.describe "Assignments", type: :request do
 
   describe "post assignments_path with valid data" do
     it "saves a new entry and redirects to the show path for the assignment" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
       expect { post customer_assignments_path(customer_id: customer.id), params: {assignment: {user_id: user.id, status: "new"}}
@@ -89,7 +91,7 @@ RSpec.describe "Assignments", type: :request do
   end
 
   describe "post assignments_path with invalid data" do
-    it "does not save a new entry and redirects to the new path for the assignment" do
+    it "doesn't save a new entry and render an edit template for the assignment" do
       user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
@@ -101,7 +103,8 @@ RSpec.describe "Assignments", type: :request do
 
   describe "put assignment_path with valid data" do
     it "updates an entry and redirects to the show path for the assignment" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
       assignment = FactoryBot.create(:assignment)
@@ -115,8 +118,9 @@ RSpec.describe "Assignments", type: :request do
   end
 
   describe "put assignment_path with invalid data" do
-    it "updates an entry and redirects to the edit path for the assignment" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+    it "doesn't update an entry and render an edit template for the assignment" do
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
       assignment = FactoryBot.create(:assignment)
@@ -130,14 +134,13 @@ RSpec.describe "Assignments", type: :request do
   end
 
   describe "delete a assignment record" do
-    it "deletes a assignment record and redirects to the index path" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+    it "deletes a assignment record and redirects to the customer index path" do
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
       assignment = FactoryBot.create(:assignment)
       customer = assignment.customer
-      # delete assignment_path(id: assignment.id)
-      # expect(response).to redirect_to customer
       expect {delete assignment_path(id: assignment.id)}.to change(Assignment, :count)
       expect(response).to redirect_to customer
      end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe "Orders", type: :request do
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
+    it "doesn't renders the :edit template for a nil role" do
+      order = FactoryBot.create(:order)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: nil)
+      sign_in user
+      get edit_order_path(id: order.id)
+      expect(response).to redirect_to new_user_session_path
+    end
     it "redirects to the new_user_session_path if a user is not logged in" do
       order = FactoryBot.create(:order)
       get edit_order_path(id: order.id)

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -17,11 +17,12 @@ RSpec.describe "Orders", type: :request do
     end
     it "renders the :show template for a volunteer role" do
       order = FactoryBot.create(:order)
+      customer = FactoryBot.create(:customer)
       user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
         password_confirmation: "Pa$$word20", role: "volunteer")
       sign_in user
       get order_path(id: order.id)
-      expect(response).to render_template(:show)
+      expect(response).to redirect_to home_index_path
     end
     it "redirects to the customer index path if the order id is invalid" do
       order = FactoryBot.create(:order)
@@ -65,13 +66,13 @@ RSpec.describe "Orders", type: :request do
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
-    it "doesn't renders the :edit template for a nil role" do
+    it "doesn't render the :edit template for a nil role" do
       order = FactoryBot.create(:order)
       user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
         password_confirmation: "Pa$$word20", role: nil)
       sign_in user
       get edit_order_path(id: order.id)
-      expect(response).to redirect_to new_user_session_path
+      expect(response).to redirect_to home_index_path
     end
     it "redirects to the new_user_session_path if a user is not logged in" do
       order = FactoryBot.create(:order)

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,38 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe "Orders", type: :request do
-  describe "get order_path for an administrator role" do
-    it "renders the :show template" do
+  describe "get show_order_path" do
+    it "doesn't render the :show template if a user is not logged in" do
       order = FactoryBot.create(:order)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      get order_path(id: order.id)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+    it "renders the :show template for an administrator role" do
+      order = FactoryBot.create(:order)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get order_path(id: order.id)
       expect(response).to render_template(:show)
     end
-  end
-
-  describe "get order_path for a volunteer role" do
-    it "renders the customer path" do
+    it "renders the :show template for a volunteer role" do
       order = FactoryBot.create(:order)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "volunteer")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "volunteer")
       sign_in user
       get order_path(id: order.id)
+      expect(response).to render_template(:show)
+    end
+    it "redirects to the customer index path if the order id is invalid" do
+      order = FactoryBot.create(:order)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
+      sign_in user
+      get order_path(id: 5000)
       expect(response).to redirect_to customers_path
     end
   end
 
+  describe "get new_customer_order_path" do
+    it "renders the :new template for an administrator role" do
+      service = FactoryBot.create(:service)
+      customer = FactoryBot.create(:customer)
+      category = FactoryBot.create(:category)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
+      sign_in user
+      get new_customer_order_path(customer_id: customer.id),
+        params: {order: {service_id: service.id, category_id: category.id, description: "new"}}
+      expect(response).to render_template(:new)
+    end
+    it "redirects to the new_user_session_path if a user is not logged in" do
+      service = FactoryBot.create(:service)
+      customer = FactoryBot.create(:customer)
+      category = FactoryBot.create(:category)
+      get new_customer_order_path(customer_id: customer.id),
+        params: {order: {service_id: service.id, category_id: category.id, description: "new"}}
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
   describe "get edit_order_path" do
-    it "renders the :edit template" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+    it "renders the :edit template for an administrator role" do
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       order = FactoryBot.create(:order)
       get edit_order_path(id: order.id)
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
-    it "redirects to the index path if the order id is invalid" do
+    it "redirects to the new_user_session_path if a user is not logged in" do
       order = FactoryBot.create(:order)
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      get edit_order_path(id: order.id)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+    it "redirects to the new_user_session_path if the order id is invalid" do
+      order = FactoryBot.create(:order)
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       get order_path(id: 1000)
       expect(response).to redirect_to customers_path
@@ -41,26 +82,30 @@ RSpec.describe "Orders", type: :request do
 
   describe "post orders_path with valid data" do
     it "saves a new entry and redirects to the show path for the order" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       service = FactoryBot.create(:service)
       customer = FactoryBot.create(:customer)
       category = FactoryBot.create(:category)
       expect { post customer_orders_path(customer_id: customer.id),
-        params: {order: {service_id: service.id, category_id: category.id,  description: "new"}}
+        params: {order: {service_id: service.id, category_id: category.id,
+        description: "new"}}
       }.to change(Order, :count)
       expect(response).to redirect_to Order.last
     end
   end
 
-  describe "post orders_path with invalid data (done)" do
-    it "saves a new entry and redirects to the show path for the order" do
-      user = User.create(email: 'test@icloud.com', password: "Password20", password_confirmation: "Pa$$word20", role: "administrator")
+  describe "post orders_path with invalid data" do
+    it "doesn't save a new entry and render an edit template for the order" do
+      user = User.create(email: 'test@icloud.com', password: "Password20", 
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       service = FactoryBot.create(:service)
       customer = FactoryBot.create(:customer)
-      expect { post customer_orders_path(customer_id: customer.id), params: {order: {
-        service_id: service.id, category_id: 5000,  description: "new"}}
+      expect { post customer_orders_path(customer_id: customer.id), 
+        params: {order: { service_id: 1000, category_id: 5000,  
+        description: nil}}
     }.not_to change(Order, :count)
       expect(response).to render_template(:edit)
     end
@@ -84,14 +129,13 @@ RSpec.describe "Orders", type: :request do
   end
 
   describe "put order_path with invalid data" do
-    it "updates an entry and redirects to the edit path for the order" do
+    it "doesn't update an entry and render an edit template for the order" do
       user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
         password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       order = FactoryBot.create(:order)
       put order_path(id: order.id), params: {order: {category_id: nil, description: ""}}
       order.reload
-      # expect(order.customer_id).not_to eq(nil)
       expect(order.category_id).not_to eq(nil)
       expect(order.description).not_to eq("")
       expect(response.status).to render_template(:edit)
@@ -99,8 +143,9 @@ RSpec.describe "Orders", type: :request do
   end
 
   describe "delete an order record" do
-    it "deletes an order record and redirects to the index path" do
-      user = User.create(email: 'test@icloud.com', password: "Pa$$word20", password_confirmation: "Pa$$word20", role: "administrator")
+    it "deletes an order record and redirects to the customer index path" do
+      user = User.create(email: 'test@icloud.com', password: "Pa$$word20",
+        password_confirmation: "Pa$$word20", role: "administrator")
       sign_in user
       customer = FactoryBot.create(:customer)
       order = FactoryBot.create(:order)


### PR DESCRIPTION
Hi @jrmcgarvey! This PR consists of non-completed rspec for orders and assignments. I've got an error for the "Orders get edit_order_path doesn't render the :edit template for a nil role":

`Expected response to be a redirect to <http://www.example.com/users/sign_in> but was a redirect to <http://www.example.com/users/sign_in?locale=en>.
 Expected "http://www.example.com/users/sign_in" to be === "http://www.example.com/users/sign_in?locale=en".`

The expected result for this test is `"http://www.example.com/users/sign_in?locale=en".` including query "locale=en" but the actual path should be "http://www.example.com/en/users/sign_in" without query. Is this a bug in routs?